### PR TITLE
Add MVVM architecture skeleton with data and UI layers

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
         android:theme="@style/Theme.DemoToDoList"
         tools:targetApi="31">
         <activity
-            android:name=".MainActivity"
+            android:name=".ui.activity.MainActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/nick/bonson/demotodolist/data/dao/TodoDao.kt
+++ b/app/src/main/java/nick/bonson/demotodolist/data/dao/TodoDao.kt
@@ -1,0 +1,17 @@
+package nick.bonson.demotodolist.data.dao
+
+import androidx.room.*
+import kotlinx.coroutines.flow.Flow
+import nick.bonson.demotodolist.data.entity.TodoEntity
+
+@Dao
+interface TodoDao {
+    @Query("SELECT * FROM todos")
+    fun getTodos(): Flow<List<TodoEntity>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(todo: TodoEntity)
+
+    @Delete
+    suspend fun delete(todo: TodoEntity)
+}

--- a/app/src/main/java/nick/bonson/demotodolist/data/db/AppDatabase.kt
+++ b/app/src/main/java/nick/bonson/demotodolist/data/db/AppDatabase.kt
@@ -1,0 +1,27 @@
+package nick.bonson.demotodolist.data.db
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import nick.bonson.demotodolist.data.dao.TodoDao
+import nick.bonson.demotodolist.data.entity.TodoEntity
+
+@Database(entities = [TodoEntity::class], version = 1)
+abstract class AppDatabase : RoomDatabase() {
+    abstract fun todoDao(): TodoDao
+
+    companion object {
+        @Volatile
+        private var INSTANCE: AppDatabase? = null
+
+        fun getInstance(context: Context): AppDatabase =
+            INSTANCE ?: synchronized(this) {
+                INSTANCE ?: Room.databaseBuilder(
+                    context.applicationContext,
+                    AppDatabase::class.java,
+                    "todo_db"
+                ).build().also { INSTANCE = it }
+            }
+    }
+}

--- a/app/src/main/java/nick/bonson/demotodolist/data/entity/TodoEntity.kt
+++ b/app/src/main/java/nick/bonson/demotodolist/data/entity/TodoEntity.kt
@@ -1,0 +1,12 @@
+package nick.bonson.demotodolist.data.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "todos")
+data class TodoEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val title: String,
+    val description: String? = null,
+    val completed: Boolean = false
+)

--- a/app/src/main/java/nick/bonson/demotodolist/data/repository/TodoRepository.kt
+++ b/app/src/main/java/nick/bonson/demotodolist/data/repository/TodoRepository.kt
@@ -1,0 +1,16 @@
+package nick.bonson.demotodolist.data.repository
+
+import kotlinx.coroutines.flow.Flow
+import nick.bonson.demotodolist.data.entity.TodoEntity
+
+interface TodoRepository {
+    fun getTodos(): Flow<List<TodoEntity>>
+    suspend fun addTodo(todo: TodoEntity)
+    suspend fun deleteTodo(todo: TodoEntity)
+}
+
+class DefaultTodoRepository(private val dao: nick.bonson.demotodolist.data.dao.TodoDao) : TodoRepository {
+    override fun getTodos(): Flow<List<TodoEntity>> = dao.getTodos()
+    override suspend fun addTodo(todo: TodoEntity) = dao.insert(todo)
+    override suspend fun deleteTodo(todo: TodoEntity) = dao.delete(todo)
+}

--- a/app/src/main/java/nick/bonson/demotodolist/model/Filter.kt
+++ b/app/src/main/java/nick/bonson/demotodolist/model/Filter.kt
@@ -1,0 +1,7 @@
+package nick.bonson.demotodolist.model
+
+enum class Filter {
+    ALL,
+    ACTIVE,
+    COMPLETED
+}

--- a/app/src/main/java/nick/bonson/demotodolist/model/Sort.kt
+++ b/app/src/main/java/nick/bonson/demotodolist/model/Sort.kt
@@ -1,0 +1,6 @@
+package nick.bonson.demotodolist.model
+
+enum class Sort {
+    BY_DATE,
+    BY_TITLE
+}

--- a/app/src/main/java/nick/bonson/demotodolist/model/UiState.kt
+++ b/app/src/main/java/nick/bonson/demotodolist/model/UiState.kt
@@ -1,0 +1,9 @@
+package nick.bonson.demotodolist.model
+
+import nick.bonson.demotodolist.data.entity.TodoEntity
+
+data class UiState(
+    val todos: List<TodoEntity> = emptyList(),
+    val filter: Filter = Filter.ALL,
+    val sort: Sort = Sort.BY_DATE
+)

--- a/app/src/main/java/nick/bonson/demotodolist/ui/activity/MainActivity.kt
+++ b/app/src/main/java/nick/bonson/demotodolist/ui/activity/MainActivity.kt
@@ -1,7 +1,8 @@
-package nick.bonson.demotodolist
+package nick.bonson.demotodolist.ui.activity
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import nick.bonson.demotodolist.R
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/nick/bonson/demotodolist/ui/adapter/TodoAdapter.kt
+++ b/app/src/main/java/nick/bonson/demotodolist/ui/adapter/TodoAdapter.kt
@@ -1,0 +1,30 @@
+package nick.bonson.demotodolist.ui.adapter
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import nick.bonson.demotodolist.R
+import nick.bonson.demotodolist.data.entity.TodoEntity
+import nick.bonson.demotodolist.utils.TodoDiffCallback
+
+class TodoAdapter : ListAdapter<TodoEntity, TodoAdapter.TodoViewHolder>(TodoDiffCallback) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TodoViewHolder {
+        val view = LayoutInflater.from(parent.context).inflate(R.layout.item_todo, parent, false)
+        return TodoViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: TodoViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    class TodoViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        private val title: TextView = itemView.findViewById(R.id.todo_title)
+        fun bind(todo: TodoEntity) {
+            title.text = todo.title
+        }
+    }
+}

--- a/app/src/main/java/nick/bonson/demotodolist/ui/fragment/TodoListFragment.kt
+++ b/app/src/main/java/nick/bonson/demotodolist/ui/fragment/TodoListFragment.kt
@@ -1,0 +1,40 @@
+package nick.bonson.demotodolist.ui.fragment
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import nick.bonson.demotodolist.R
+import nick.bonson.demotodolist.data.db.AppDatabase
+import nick.bonson.demotodolist.data.repository.DefaultTodoRepository
+import nick.bonson.demotodolist.ui.adapter.TodoAdapter
+import nick.bonson.demotodolist.ui.viewmodel.TodoViewModel
+import nick.bonson.demotodolist.ui.viewmodel.TodoViewModelFactory
+
+class TodoListFragment : Fragment() {
+
+    private val viewModel: TodoViewModel by viewModels {
+        val context = requireContext().applicationContext
+        val dao = AppDatabase.getInstance(context).todoDao()
+        val repository = DefaultTodoRepository(dao)
+        TodoViewModelFactory(repository)
+    }
+    private lateinit var recyclerView: RecyclerView
+    private val adapter = TodoAdapter()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        val view = inflater.inflate(R.layout.fragment_todo_list, container, false)
+        recyclerView = view.findViewById(R.id.todo_list)
+        recyclerView.layoutManager = LinearLayoutManager(requireContext())
+        recyclerView.adapter = adapter
+        return view
+    }
+}

--- a/app/src/main/java/nick/bonson/demotodolist/ui/viewmodel/TodoViewModel.kt
+++ b/app/src/main/java/nick/bonson/demotodolist/ui/viewmodel/TodoViewModel.kt
@@ -1,0 +1,30 @@
+package nick.bonson.demotodolist.ui.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import nick.bonson.demotodolist.data.entity.TodoEntity
+import nick.bonson.demotodolist.data.repository.TodoRepository
+import nick.bonson.demotodolist.model.UiState
+
+class TodoViewModel(private val repository: TodoRepository) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(UiState())
+    val uiState: StateFlow<UiState> = _uiState
+
+    init {
+        viewModelScope.launch {
+            repository.getTodos().collect { todos ->
+                _uiState.value = _uiState.value.copy(todos = todos)
+            }
+        }
+    }
+
+    fun addTodo(title: String) {
+        viewModelScope.launch {
+            repository.addTodo(TodoEntity(title = title))
+        }
+    }
+}

--- a/app/src/main/java/nick/bonson/demotodolist/ui/viewmodel/TodoViewModelFactory.kt
+++ b/app/src/main/java/nick/bonson/demotodolist/ui/viewmodel/TodoViewModelFactory.kt
@@ -1,0 +1,15 @@
+package nick.bonson.demotodolist.ui.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import nick.bonson.demotodolist.data.repository.TodoRepository
+
+class TodoViewModelFactory(private val repository: TodoRepository) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(TodoViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return TodoViewModel(repository) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}

--- a/app/src/main/java/nick/bonson/demotodolist/utils/DateFormatter.kt
+++ b/app/src/main/java/nick/bonson/demotodolist/utils/DateFormatter.kt
@@ -1,0 +1,11 @@
+package nick.bonson.demotodolist.utils
+
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+object DateFormatter {
+    private val formatter = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+
+    fun format(date: Date): String = formatter.format(date)
+}

--- a/app/src/main/java/nick/bonson/demotodolist/utils/TodoDiffCallback.kt
+++ b/app/src/main/java/nick/bonson/demotodolist/utils/TodoDiffCallback.kt
@@ -1,0 +1,9 @@
+package nick.bonson.demotodolist.utils
+
+import androidx.recyclerview.widget.DiffUtil
+import nick.bonson.demotodolist.data.entity.TodoEntity
+
+object TodoDiffCallback : DiffUtil.ItemCallback<TodoEntity>() {
+    override fun areItemsTheSame(oldItem: TodoEntity, newItem: TodoEntity): Boolean = oldItem.id == newItem.id
+    override fun areContentsTheSame(oldItem: TodoEntity, newItem: TodoEntity): Boolean = oldItem == newItem
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.fragment.app.FragmentContainerView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/nav_host_fragment"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    tools:context=".MainActivity">
-
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/app_name" />
-</LinearLayout>
+    app:defaultNavHost="false"
+    android:name="nick.bonson.demotodolist.ui.fragment.TodoListFragment"
+    tools:context=".ui.activity.MainActivity" />

--- a/app/src/main/res/layout/fragment_todo_list.xml
+++ b/app/src/main/res/layout/fragment_todo_list.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/todo_list"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_todo.xml
+++ b/app/src/main/res/layout/item_todo.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/todo_title"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="16dp"
+    android:textSize="16sp" />


### PR DESCRIPTION
## Summary
- organize data layer with Room entity, DAO, repository, and database
- introduce ui layer components (activity, fragment, viewmodel, adapter) using the repository pattern
- add model and utility classes for UI state management and formatting

## Testing
- no tests were run


------
https://chatgpt.com/codex/tasks/task_e_68a62e4b3028832cba947c9ac6e2fc41