### PR TITLE
Implement Room Task data layer

### DIFF
--- a/app/src/main/java/nick/bonson/demotodolist/data/dao/TaskDao.kt
+++ b/app/src/main/java/nick/bonson/demotodolist/data/dao/TaskDao.kt
@@ -1,0 +1,52 @@
+package nick.bonson.demotodolist.data.dao
+
+import androidx.room.*
+import kotlinx.coroutines.flow.Flow
+import nick.bonson.demotodolist.data.entity.TaskEntity
+import nick.bonson.demotodolist.model.Filter
+import nick.bonson.demotodolist.model.TaskSort
+
+@Dao
+interface TaskDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(task: TaskEntity)
+
+    @Update
+    suspend fun update(task: TaskEntity)
+
+    @Delete
+    suspend fun delete(task: TaskEntity)
+
+    @Query(
+        """
+        SELECT * FROM tasks
+        ORDER BY
+            CASE WHEN :sortMode = 0 THEN dueAt END ASC,
+            CASE WHEN :sortMode = 1 THEN priority END DESC
+        """
+    )
+    fun getAllFlow(sortMode: TaskSort): Flow<List<TaskEntity>>
+
+    @Query(
+        """
+        SELECT * FROM tasks
+        WHERE isDone = :isDone
+        ORDER BY
+            CASE WHEN :sortMode = 0 THEN dueAt END ASC,
+            CASE WHEN :sortMode = 1 THEN priority END DESC
+        """
+    )
+    fun getByStatusFlow(isDone: Boolean, sortMode: TaskSort): Flow<List<TaskEntity>>
+
+    @Query(
+        """
+        SELECT * FROM tasks
+        WHERE title LIKE '%' || :query || '%'
+        AND (:filter = 0 OR (:filter = 1 AND isDone = 0) OR (:filter = 2 AND isDone = 1))
+        ORDER BY
+            CASE WHEN :sortMode = 0 THEN dueAt END ASC,
+            CASE WHEN :sortMode = 1 THEN priority END DESC
+        """
+    )
+    fun searchFlow(query: String, filter: Filter, sortMode: TaskSort): Flow<List<TaskEntity>>
+}

--- a/app/src/main/java/nick/bonson/demotodolist/data/db/AppDatabase.kt
+++ b/app/src/main/java/nick/bonson/demotodolist/data/db/AppDatabase.kt
@@ -4,12 +4,15 @@ import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import nick.bonson.demotodolist.data.dao.TaskDao
 import nick.bonson.demotodolist.data.dao.TodoDao
+import nick.bonson.demotodolist.data.entity.TaskEntity
 import nick.bonson.demotodolist.data.entity.TodoEntity
 
-@Database(entities = [TodoEntity::class], version = 1)
+@Database(entities = [TodoEntity::class, TaskEntity::class], version = 1)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun todoDao(): TodoDao
+    abstract fun taskDao(): TaskDao
 
     companion object {
         @Volatile

--- a/app/src/main/java/nick/bonson/demotodolist/data/entity/TaskEntity.kt
+++ b/app/src/main/java/nick/bonson/demotodolist/data/entity/TaskEntity.kt
@@ -1,0 +1,22 @@
+package nick.bonson.demotodolist.data.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import androidx.room.Index
+
+@Entity(
+    tableName = "tasks",
+    indices = [
+        Index(value = ["isDone"]),
+        Index(value = ["priority"]),
+        Index(value = ["dueAt"])
+    ]
+)
+data class TaskEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val title: String,
+    val description: String? = null,
+    val isDone: Boolean = false,
+    val priority: Int = 0,
+    val dueAt: Long? = null
+)

--- a/app/src/main/java/nick/bonson/demotodolist/data/repository/TaskRepository.kt
+++ b/app/src/main/java/nick/bonson/demotodolist/data/repository/TaskRepository.kt
@@ -1,0 +1,32 @@
+package nick.bonson.demotodolist.data.repository
+
+import kotlinx.coroutines.flow.Flow
+import nick.bonson.demotodolist.data.dao.TaskDao
+import nick.bonson.demotodolist.data.entity.TaskEntity
+import nick.bonson.demotodolist.model.Filter
+import nick.bonson.demotodolist.model.TaskSort
+
+interface TaskRepository {
+    fun getAllFlow(sortMode: TaskSort): Flow<List<TaskEntity>>
+    fun getByStatusFlow(isDone: Boolean, sortMode: TaskSort): Flow<List<TaskEntity>>
+    fun searchFlow(query: String, filter: Filter, sortMode: TaskSort): Flow<List<TaskEntity>>
+    suspend fun insert(task: TaskEntity)
+    suspend fun update(task: TaskEntity)
+    suspend fun delete(task: TaskEntity)
+}
+
+class DefaultTaskRepository(private val dao: TaskDao) : TaskRepository {
+    override fun getAllFlow(sortMode: TaskSort): Flow<List<TaskEntity>> = dao.getAllFlow(sortMode)
+
+    override fun getByStatusFlow(isDone: Boolean, sortMode: TaskSort): Flow<List<TaskEntity>> =
+        dao.getByStatusFlow(isDone, sortMode)
+
+    override fun searchFlow(query: String, filter: Filter, sortMode: TaskSort): Flow<List<TaskEntity>> =
+        dao.searchFlow(query, filter, sortMode)
+
+    override suspend fun insert(task: TaskEntity) = dao.insert(task)
+
+    override suspend fun update(task: TaskEntity) = dao.update(task)
+
+    override suspend fun delete(task: TaskEntity) = dao.delete(task)
+}

--- a/app/src/main/java/nick/bonson/demotodolist/model/TaskSort.kt
+++ b/app/src/main/java/nick/bonson/demotodolist/model/TaskSort.kt
@@ -1,0 +1,6 @@
+package nick.bonson.demotodolist.model
+
+enum class TaskSort {
+    BY_DUE_AT,
+    BY_PRIORITY
+}


### PR DESCRIPTION
## Summary
- add TaskEntity with indices for status, priority and due date
- create TaskDao with CRUD and query flows
- extend AppDatabase and add TaskRepository

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68a62fd70c90832c82fc511b9d933c40