### PR TITLE
Add task list view model and UI state

### DIFF
--- a/app/src/main/java/nick/bonson/demotodolist/model/TaskListUiState.kt
+++ b/app/src/main/java/nick/bonson/demotodolist/model/TaskListUiState.kt
@@ -1,0 +1,16 @@
+package nick.bonson.demotodolist.model
+
+import nick.bonson.demotodolist.data.entity.TaskEntity
+
+// Holds UI state for displaying a list of tasks
+// items - list of tasks, filter - current filter, sort - sorting mode, query - search query, isEmpty - whether list is empty
+// isEmpty is maintained separately to simplify observing empty state in UI
+
+data class TaskListUiState(
+    val items: List<TaskEntity> = emptyList(),
+    val filter: Filter = Filter.ALL,
+    val sort: TaskSort = TaskSort.BY_DUE_AT,
+    val query: String = "",
+    val isEmpty: Boolean = true
+)
+

--- a/app/src/main/java/nick/bonson/demotodolist/ui/viewmodel/TaskListViewModel.kt
+++ b/app/src/main/java/nick/bonson/demotodolist/ui/viewmodel/TaskListViewModel.kt
@@ -1,0 +1,85 @@
+package nick.bonson.demotodolist.ui.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import nick.bonson.demotodolist.data.entity.TaskEntity
+import nick.bonson.demotodolist.data.repository.TaskRepository
+import nick.bonson.demotodolist.model.Filter
+import nick.bonson.demotodolist.model.TaskListUiState
+import nick.bonson.demotodolist.model.TaskSort
+
+/**
+ * ViewModel responsible for managing a list of [TaskEntity].
+ * It exposes a [StateFlow] of [TaskListUiState] that the UI can observe.
+ */
+class TaskListViewModel(private val repository: TaskRepository) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(TaskListUiState())
+    val uiState: StateFlow<TaskListUiState> = _uiState
+
+    private var observeJob: Job? = null
+
+    init {
+        observeTasks()
+    }
+
+    private fun observeTasks() {
+        observeJob?.cancel()
+        observeJob = viewModelScope.launch {
+            val state = _uiState.value
+            val flow = when {
+                state.query.isNotEmpty() -> repository.searchFlow(state.query, state.filter, state.sort)
+                state.filter == Filter.ALL -> repository.getAllFlow(state.sort)
+                else -> repository.getByStatusFlow(
+                    isDone = state.filter == Filter.COMPLETED,
+                    sortMode = state.sort
+                )
+            }
+            flow.collect { tasks ->
+                _uiState.value = _uiState.value.copy(items = tasks, isEmpty = tasks.isEmpty())
+            }
+        }
+    }
+
+    fun onAdd(task: TaskEntity) {
+        viewModelScope.launch {
+            repository.insert(task)
+        }
+    }
+
+    fun onEdit(task: TaskEntity) {
+        viewModelScope.launch {
+            repository.update(task)
+        }
+    }
+
+    fun onDelete(task: TaskEntity) {
+        viewModelScope.launch {
+            repository.delete(task)
+        }
+    }
+
+    fun onToggleDone(task: TaskEntity) {
+        onEdit(task.copy(isDone = !task.isDone))
+    }
+
+    fun onSearch(query: String) {
+        _uiState.value = _uiState.value.copy(query = query)
+        observeTasks()
+    }
+
+    fun onFilterChanged(filter: Filter) {
+        _uiState.value = _uiState.value.copy(filter = filter)
+        observeTasks()
+    }
+
+    fun onSortChanged(sort: TaskSort) {
+        _uiState.value = _uiState.value.copy(sort = sort)
+        observeTasks()
+    }
+}
+


### PR DESCRIPTION
## Summary
- introduce `TaskListUiState` to hold tasks, filters, sorting and search query
- add `TaskListViewModel` with CRUD and state management methods and DAO Flow mapping

## Testing
- No tests were run due to user request

------
https://chatgpt.com/codex/tasks/task_e_68a6318bb714832c9cccd6aa29eb3358