### PR TITLE
Remove defaultNavHost attribute from main layout

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.fragment.app.FragmentContainerView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/nav_host_fragment"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    app:defaultNavHost="false"
     android:name="nick.bonson.demotodolist.ui.fragment.TodoListFragment"
     tools:context=".ui.activity.MainActivity" />


### PR DESCRIPTION
## Summary
- remove unsupported `defaultNavHost` attribute and unused `app` namespace from `activity_main.xml`

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68a637f29ec0832cb4ee32bf3ca78370