### PR TITLE
Add modal bottom sheet for tasks

### DIFF
--- a/app/src/main/java/nick/bonson/demotodolist/ui/adapter/TaskAdapter.kt
+++ b/app/src/main/java/nick/bonson/demotodolist/ui/adapter/TaskAdapter.kt
@@ -10,20 +10,29 @@ import nick.bonson.demotodolist.R
 import nick.bonson.demotodolist.data.entity.TaskEntity
 import nick.bonson.demotodolist.utils.TaskDiffCallback
 
-class TaskAdapter : ListAdapter<TaskEntity, TaskAdapter.TaskViewHolder>(TaskDiffCallback) {
+class TaskAdapter(private val onItemClick: (TaskEntity) -> Unit) :
+    ListAdapter<TaskEntity, TaskAdapter.TaskViewHolder>(TaskDiffCallback) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TaskViewHolder {
         val view = LayoutInflater.from(parent.context).inflate(R.layout.item_task, parent, false)
-        return TaskViewHolder(view)
+        return TaskViewHolder(view, onItemClick)
     }
 
     override fun onBindViewHolder(holder: TaskViewHolder, position: Int) {
         holder.bind(getItem(position))
     }
 
-    class TaskViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+    class TaskViewHolder(itemView: View, private val onItemClick: (TaskEntity) -> Unit) :
+        RecyclerView.ViewHolder(itemView) {
         private val title: TextView = itemView.findViewById(R.id.task_title)
+        private var current: TaskEntity? = null
+
+        init {
+            itemView.setOnClickListener { current?.let(onItemClick) }
+        }
+
         fun bind(task: TaskEntity) {
+            current = task
             title.text = task.title
         }
     }

--- a/app/src/main/java/nick/bonson/demotodolist/ui/fragment/TaskEditBottomSheet.kt
+++ b/app/src/main/java/nick/bonson/demotodolist/ui/fragment/TaskEditBottomSheet.kt
@@ -1,0 +1,139 @@
+package nick.bonson.demotodolist.ui.fragment
+
+import android.app.DatePickerDialog
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ArrayAdapter
+import android.widget.AutoCompleteTextView
+import android.widget.Button
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.google.android.material.textfield.TextInputEditText
+import androidx.fragment.app.activityViewModels
+import nick.bonson.demotodolist.R
+import nick.bonson.demotodolist.data.db.AppDatabase
+import nick.bonson.demotodolist.data.entity.TaskEntity
+import nick.bonson.demotodolist.data.repository.DefaultTaskRepository
+import nick.bonson.demotodolist.ui.viewmodel.TaskListViewModel
+import nick.bonson.demotodolist.ui.viewmodel.TaskListViewModelFactory
+import nick.bonson.demotodolist.utils.DateFormatter
+import java.util.Calendar
+import java.util.Date
+
+class TaskEditBottomSheet : BottomSheetDialogFragment() {
+
+    private val viewModel: TaskListViewModel by activityViewModels {
+        val context = requireContext().applicationContext
+        val dao = AppDatabase.getInstance(context).taskDao()
+        val repository = DefaultTaskRepository(dao)
+        TaskListViewModelFactory(repository)
+    }
+
+    private var taskId: Long = 0L
+    private var isDone: Boolean = false
+    private var priority: Int = 0
+    private var dueAt: Long? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        arguments?.let {
+            taskId = it.getLong(ARG_ID, 0L)
+            isDone = it.getBoolean(ARG_DONE, false)
+            priority = it.getInt(ARG_PRIORITY, 0)
+            if (it.containsKey(ARG_DUE_AT)) {
+                dueAt = it.getLong(ARG_DUE_AT)
+            }
+        }
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        val view = inflater.inflate(R.layout.dialog_task_edit, container, false)
+        val titleInput = view.findViewById<TextInputEditText>(R.id.input_title)
+        val notesInput = view.findViewById<TextInputEditText>(R.id.input_notes)
+        val priorityInput = view.findViewById<AutoCompleteTextView>(R.id.input_priority)
+        val dueDateInput = view.findViewById<TextInputEditText>(R.id.input_due_date)
+        val saveButton = view.findViewById<Button>(R.id.button_save)
+        val cancelButton = view.findViewById<Button>(R.id.button_cancel)
+
+        titleInput.setText(arguments?.getString(ARG_TITLE).orEmpty())
+        notesInput.setText(arguments?.getString(ARG_NOTES).orEmpty())
+
+        val priorities = resources.getStringArray(R.array.priority_entries)
+        priorityInput.setAdapter(ArrayAdapter(requireContext(), android.R.layout.simple_list_item_1, priorities))
+        priorityInput.setText(priorities[priority], false)
+        priorityInput.setOnItemClickListener { _, _, position, _ -> priority = position }
+
+        dueAt?.let {
+            dueDateInput.setText(DateFormatter.format(Date(it)))
+        }
+        dueDateInput.setOnClickListener {
+            val calendar = Calendar.getInstance()
+            dueAt?.let { calendar.timeInMillis = it }
+            DatePickerDialog(requireContext(), { _, year, month, day ->
+                calendar.set(year, month, day, 0, 0, 0)
+                dueAt = calendar.timeInMillis
+                dueDateInput.setText(DateFormatter.format(Date(dueAt!!)))
+            },
+                calendar.get(Calendar.YEAR),
+                calendar.get(Calendar.MONTH),
+                calendar.get(Calendar.DAY_OF_MONTH)
+            ).show()
+        }
+
+        saveButton.setOnClickListener {
+            val title = titleInput.text?.toString()?.trim()
+            if (title.isNullOrEmpty()) {
+                titleInput.error = getString(R.string.error_required)
+                return@setOnClickListener
+            }
+            val description = notesInput.text?.toString()?.trim().takeIf { it?.isNotEmpty() == true }
+            val task = TaskEntity(
+                id = taskId,
+                title = title,
+                description = description,
+                isDone = isDone,
+                priority = priority,
+                dueAt = dueAt
+            )
+            if (taskId == 0L) {
+                viewModel.onAdd(task)
+            } else {
+                viewModel.onEdit(task)
+            }
+            dismiss()
+        }
+
+        cancelButton.setOnClickListener { dismiss() }
+
+        return view
+    }
+
+    companion object {
+        private const val ARG_ID = "id"
+        private const val ARG_TITLE = "title"
+        private const val ARG_NOTES = "notes"
+        private const val ARG_PRIORITY = "priority"
+        private const val ARG_DUE_AT = "due_at"
+        private const val ARG_DONE = "done"
+
+        fun newInstance(task: TaskEntity? = null): TaskEditBottomSheet {
+            val fragment = TaskEditBottomSheet()
+            fragment.arguments = Bundle().apply {
+                if (task != null) {
+                    putLong(ARG_ID, task.id)
+                    putString(ARG_TITLE, task.title)
+                    putString(ARG_NOTES, task.description)
+                    putInt(ARG_PRIORITY, task.priority)
+                    task.dueAt?.let { putLong(ARG_DUE_AT, it) }
+                    putBoolean(ARG_DONE, task.isDone)
+                }
+            }
+            return fragment
+        }
+    }
+}

--- a/app/src/main/java/nick/bonson/demotodolist/ui/fragment/TaskListFragment.kt
+++ b/app/src/main/java/nick/bonson/demotodolist/ui/fragment/TaskListFragment.kt
@@ -32,7 +32,7 @@ class TaskListFragment : Fragment(R.layout.fragment_task_list) {
         TaskListViewModelFactory(repository)
     }
 
-    private val adapter = TaskAdapter()
+    private val adapter = TaskAdapter { task -> showTaskSheet(task) }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -80,9 +80,7 @@ class TaskListFragment : Fragment(R.layout.fragment_task_list) {
             viewModel.onFilterChanged(filter)
         }
 
-        fab.setOnClickListener {
-            viewModel.onAdd(TaskEntity(title = "New Task"))
-        }
+        fab.setOnClickListener { showTaskSheet(null) }
 
         emptyButton.setOnClickListener { fab.performClick() }
 
@@ -106,5 +104,9 @@ class TaskListFragment : Fragment(R.layout.fragment_task_list) {
             }
         })
         touchHelper.attachToRecyclerView(recyclerView)
+    }
+
+    private fun showTaskSheet(task: TaskEntity? = null) {
+        TaskEditBottomSheet.newInstance(task).show(childFragmentManager, "TaskEdit")
     }
 }

--- a/app/src/main/res/layout/dialog_task_edit.xml
+++ b/app/src/main/res/layout/dialog_task_edit.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/title">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/input_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:hint="@string/notes">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/input_notes"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/priority_layout"
+        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:hint="@string/priority">
+
+        <AutoCompleteTextView
+            android:id="@+id/input_priority"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:hint="@string/due_date">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/input_due_date"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:focusable="false"
+            android:clickable="true" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_marginTop="16dp"
+        android:gravity="end">
+
+        <Button
+            android:id="@+id/button_cancel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/cancel" />
+
+        <Button
+            android:id="@+id/button_save"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:text="@string/save" />
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,0 +1,7 @@
+<resources>
+    <string-array name="priority_entries">
+        <item>@string/priority_low</item>
+        <item>@string/priority_medium</item>
+        <item>@string/priority_high</item>
+    </string-array>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,4 +6,14 @@
     <string name="filter_all">All</string>
     <string name="filter_active">Active</string>
     <string name="filter_done">Done</string>
+    <string name="title">Title</string>
+    <string name="notes">Notes</string>
+    <string name="priority">Priority</string>
+    <string name="due_date">Due date</string>
+    <string name="save">Save</string>
+    <string name="cancel">Cancel</string>
+    <string name="priority_low">Low</string>
+    <string name="priority_medium">Medium</string>
+    <string name="priority_high">High</string>
+    <string name="error_required">Required</string>
 </resources>


### PR DESCRIPTION
## Summary
- add modal bottom sheet to create or edit tasks with title, notes, priority and due date
- open bottom sheet from FAB or list item tap
- wire priority options and new string resources

## Testing
- `sh gradlew --version` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a63b473eb0832cb0cac03e461e9eff