### PR TITLE
Add layout size attributes to chip filters

### DIFF
--- a/app/src/main/res/layout/fragment_task_list.xml
+++ b/app/src/main/res/layout/fragment_task_list.xml
@@ -31,18 +31,24 @@
 
             <com.google.android.material.chip.Chip
                 android:id="@+id/chip_all"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
                 style="@style/Widget.MaterialComponents.Chip.Choice"
                 android:text="@string/filter_all"
                 app:checkedIconVisible="false" />
 
             <com.google.android.material.chip.Chip
                 android:id="@+id/chip_active"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
                 style="@style/Widget.MaterialComponents.Chip.Choice"
                 android:text="@string/filter_active"
                 app:checkedIconVisible="false" />
 
             <com.google.android.material.chip.Chip
                 android:id="@+id/chip_done"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
                 style="@style/Widget.MaterialComponents.Chip.Choice"
                 android:text="@string/filter_done"
                 app:checkedIconVisible="false" />


### PR DESCRIPTION
## Summary
- Set `layout_width` and `layout_height` for chip filters to avoid inflation crash

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68a63cb82dac832c85ce238f8a5d9e8d