### PR TITLE
feat: add task adapter item layout

### DIFF
--- a/app/src/main/java/nick/bonson/demotodolist/ui/adapter/TaskAdapter.kt
+++ b/app/src/main/java/nick/bonson/demotodolist/ui/adapter/TaskAdapter.kt
@@ -6,9 +6,13 @@ import android.view.ViewGroup
 import android.widget.TextView
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.chip.Chip
+import com.google.android.material.checkbox.MaterialCheckBox
 import nick.bonson.demotodolist.R
 import nick.bonson.demotodolist.data.entity.TaskEntity
+import nick.bonson.demotodolist.utils.DateFormatter
 import nick.bonson.demotodolist.utils.TaskDiffCallback
+import java.util.Date
 
 class TaskAdapter(private val onItemClick: (TaskEntity) -> Unit) :
     ListAdapter<TaskEntity, TaskAdapter.TaskViewHolder>(TaskDiffCallback) {
@@ -24,7 +28,11 @@ class TaskAdapter(private val onItemClick: (TaskEntity) -> Unit) :
 
     class TaskViewHolder(itemView: View, private val onItemClick: (TaskEntity) -> Unit) :
         RecyclerView.ViewHolder(itemView) {
+        private val checkBox: MaterialCheckBox = itemView.findViewById(R.id.task_checkbox)
         private val title: TextView = itemView.findViewById(R.id.task_title)
+        private val notes: TextView = itemView.findViewById(R.id.task_notes)
+        private val priorityChip: Chip = itemView.findViewById(R.id.chip_priority)
+        private val dueChip: Chip = itemView.findViewById(R.id.chip_due)
         private var current: TaskEntity? = null
 
         init {
@@ -33,7 +41,13 @@ class TaskAdapter(private val onItemClick: (TaskEntity) -> Unit) :
 
         fun bind(task: TaskEntity) {
             current = task
+            checkBox.isChecked = task.isDone
             title.text = task.title
+            notes.text = task.description.orEmpty()
+            notes.visibility = if (task.description.isNullOrBlank()) View.GONE else View.VISIBLE
+            priorityChip.text = task.priority.toString()
+            dueChip.text = task.dueAt?.let { DateFormatter.format(Date(it)) } ?: ""
+            dueChip.visibility = if (task.dueAt != null) View.VISIBLE else View.GONE
         }
     }
 }

--- a/app/src/main/res/layout/item_task.xml
+++ b/app/src/main/res/layout/item_task.xml
@@ -1,7 +1,75 @@
 <?xml version="1.0" encoding="utf-8"?>
-<TextView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/task_title"
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:padding="16dp"
-    android:textSize="16sp" />
+    android:layout_margin="8dp">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="8dp">
+
+        <com.google.android.material.checkbox.MaterialCheckBox
+            android:id="@+id/task_checkbox"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent" />
+
+        <LinearLayout
+            android:id="@+id/text_container"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingStart="8dp"
+            android:paddingEnd="8dp"
+            app:layout_constraintStart_toEndOf="@id/task_checkbox"
+            app:layout_constraintEnd_toStartOf="@id/chip_group"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent">
+
+            <TextView
+                android:id="@+id/task_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textStyle="bold"
+                android:maxLines="1"
+                android:ellipsize="end" />
+
+            <TextView
+                android:id="@+id/task_notes"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:maxLines="1"
+                android:ellipsize="end"
+                android:textSize="12sp" />
+        </LinearLayout>
+
+        <com.google.android.material.chip.ChipGroup
+            android:id="@+id/chip_group"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:singleLine="true"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent">
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/chip_priority"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                style="@style/Widget.MaterialComponents.Chip.Assist" />
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/chip_due"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                style="@style/Widget.MaterialComponents.Chip.Assist" />
+        </com.google.android.material.chip.ChipGroup>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</com.google.android.material.card.MaterialCardView>
+


### PR DESCRIPTION
## Summary
- add MaterialCardView layout for task list items with checkbox, notes, and chips
- bind new views in TaskAdapter using DiffUtil for animations

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68a63d0febd8832c97c1a09a90fac8e2