### PR TITLE
Fix resource linking for chip style

### DIFF
--- a/app/src/main/res/layout/item_task.xml
+++ b/app/src/main/res/layout/item_task.xml
@@ -60,13 +60,13 @@
                 android:id="@+id/chip_priority"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                style="@style/Widget.MaterialComponents.Chip.Assist" />
+                style="@style/Widget.MaterialComponents.Chip.Action" />
 
             <com.google.android.material.chip.Chip
                 android:id="@+id/chip_due"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                style="@style/Widget.MaterialComponents.Chip.Assist" />
+                style="@style/Widget.MaterialComponents.Chip.Action" />
         </com.google.android.material.chip.ChipGroup>
 
     </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Summary
- replace missing Widget.MaterialComponents.Chip.Assist style with Widget.MaterialComponents.Chip.Action

## Testing
- no tests or compilation run as per request

------
https://chatgpt.com/codex/tasks/task_e_68a63e8fb7b8832cb8624e43d6360a5f