### PR TITLE
feat: persist search filter and sort

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
     implementation(libs.androidx.recyclerview)
     implementation(libs.androidx.material3)
     implementation(libs.kotlinx.coroutines.android)
+    implementation(libs.androidx.datastore.preferences)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/nick/bonson/demotodolist/data/preferences/TaskPreferences.kt
+++ b/app/src/main/java/nick/bonson/demotodolist/data/preferences/TaskPreferences.kt
@@ -1,0 +1,49 @@
+package nick.bonson.demotodolist.data.preferences
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import nick.bonson.demotodolist.model.Filter
+import nick.bonson.demotodolist.model.TaskSort
+
+private val Context.dataStore by preferencesDataStore(name = "task_prefs")
+
+/**
+ * Handles persistence of task list UI state using [androidx.datastore.preferences.core.PreferencesDataStore].
+ */
+class TaskPreferences(private val context: Context) {
+
+    private object Keys {
+        val FILTER = stringPreferencesKey("filter")
+        val SORT = stringPreferencesKey("sort")
+        val QUERY = stringPreferencesKey("query")
+    }
+
+    val filterFlow: Flow<Filter> = context.dataStore.data.map { prefs ->
+        Filter.valueOf(prefs[Keys.FILTER] ?: Filter.ALL.name)
+    }
+
+    val sortFlow: Flow<TaskSort> = context.dataStore.data.map { prefs ->
+        TaskSort.valueOf(prefs[Keys.SORT] ?: TaskSort.BY_DUE_AT.name)
+    }
+
+    val queryFlow: Flow<String> = context.dataStore.data.map { prefs ->
+        prefs[Keys.QUERY] ?: ""
+    }
+
+    suspend fun setFilter(filter: Filter) {
+        context.dataStore.edit { it[Keys.FILTER] = filter.name }
+    }
+
+    suspend fun setSort(sort: TaskSort) {
+        context.dataStore.edit { it[Keys.SORT] = sort.name }
+    }
+
+    suspend fun setQuery(query: String) {
+        context.dataStore.edit { it[Keys.QUERY] = query }
+    }
+}
+

--- a/app/src/main/java/nick/bonson/demotodolist/ui/viewmodel/TaskListViewModelFactory.kt
+++ b/app/src/main/java/nick/bonson/demotodolist/ui/viewmodel/TaskListViewModelFactory.kt
@@ -2,13 +2,17 @@ package nick.bonson.demotodolist.ui.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import nick.bonson.demotodolist.data.preferences.TaskPreferences
 import nick.bonson.demotodolist.data.repository.TaskRepository
 
-class TaskListViewModelFactory(private val repository: TaskRepository) : ViewModelProvider.Factory {
+class TaskListViewModelFactory(
+    private val repository: TaskRepository,
+    private val preferences: TaskPreferences
+) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(TaskListViewModel::class.java)) {
             @Suppress("UNCHECKED_CAST")
-            return TaskListViewModel(repository) as T
+            return TaskListViewModel(repository, preferences) as T
         }
         throw IllegalArgumentException("Unknown ViewModel class")
     }

--- a/app/src/main/res/menu/menu_task_list.xml
+++ b/app/src/main/res/menu/menu_task_list.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <group android:checkableBehavior="single">
+        <item
+            android:id="@+id/action_sort_due"
+            android:title="@string/sort_by_due_date"
+            android:checkable="true" />
+        <item
+            android:id="@+id/action_sort_priority"
+            android:title="@string/sort_by_priority"
+            android:checkable="true" />
+    </group>
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,4 +16,6 @@
     <string name="priority_medium">Medium</string>
     <string name="priority_high">High</string>
     <string name="error_required">Required</string>
+    <string name="sort_by_due_date">Sort by due date</string>
+    <string name="sort_by_priority">Sort by priority</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ recyclerview = "1.4.0"
 material3 = "1.3.2"
 coroutines = "1.9.0"
 fragmentKtx = "1.8.9"
+datastore = "1.1.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -31,6 +32,7 @@ androidx-recyclerview = { group = "androidx.recyclerview", name = "recyclerview"
 androidx-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "material3" }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
 androidx-fragment-ktx = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "fragmentKtx" }
+androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- add DataStore-backed TaskPreferences to save filter, sort and query
- hook TaskListViewModel and TaskListFragment into TaskPreferences and sort menu

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68a63e8145d4832c90cf368d2af12010