### PR TITLE
Fix preferences injection in TaskEditBottomSheet

### DIFF
--- a/app/src/main/java/nick/bonson/demotodolist/ui/fragment/TaskEditBottomSheet.kt
+++ b/app/src/main/java/nick/bonson/demotodolist/ui/fragment/TaskEditBottomSheet.kt
@@ -15,6 +15,7 @@ import nick.bonson.demotodolist.R
 import nick.bonson.demotodolist.data.db.AppDatabase
 import nick.bonson.demotodolist.data.entity.TaskEntity
 import nick.bonson.demotodolist.data.repository.DefaultTaskRepository
+import nick.bonson.demotodolist.data.preferences.TaskPreferences
 import nick.bonson.demotodolist.ui.viewmodel.TaskListViewModel
 import nick.bonson.demotodolist.ui.viewmodel.TaskListViewModelFactory
 import nick.bonson.demotodolist.utils.DateFormatter
@@ -27,7 +28,8 @@ class TaskEditBottomSheet : BottomSheetDialogFragment() {
         val context = requireContext().applicationContext
         val dao = AppDatabase.getInstance(context).taskDao()
         val repository = DefaultTaskRepository(dao)
-        TaskListViewModelFactory(repository)
+        val prefs = TaskPreferences(context)
+        TaskListViewModelFactory(repository, prefs)
     }
 
     private var taskId: Long = 0L


### PR DESCRIPTION
## Summary
- pass `TaskPreferences` to `TaskListViewModelFactory` in `TaskEditBottomSheet`

No tests run due to user request.

------
https://chatgpt.com/codex/tasks/task_e_68a644d90e48832cb381d28c10bba0c2