### PR TITLE
Handle pre-O date conversion in TaskEditBottomSheet

### DIFF
--- a/app/src/main/java/nick/bonson/demotodolist/ui/fragment/TaskEditBottomSheet.kt
+++ b/app/src/main/java/nick/bonson/demotodolist/ui/fragment/TaskEditBottomSheet.kt
@@ -23,6 +23,7 @@ import nick.bonson.demotodolist.utils.DateFormatter
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
+import java.util.Calendar
 
 class TaskEditBottomSheet : BottomSheetDialogFragment() {
 
@@ -80,7 +81,12 @@ class TaskEditBottomSheet : BottomSheetDialogFragment() {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                     Instant.ofEpochMilli(it).atZone(ZoneId.systemDefault()).toLocalDate()
                 } else {
-                    TODO("VERSION.SDK_INT < O")
+                    val calendar = Calendar.getInstance().apply { timeInMillis = it }
+                    LocalDate.of(
+                        calendar.get(Calendar.YEAR),
+                        calendar.get(Calendar.MONTH) + 1,
+                        calendar.get(Calendar.DAY_OF_MONTH)
+                    )
                 }
             } ?: LocalDate.now()
 


### PR DESCRIPTION
## Summary
- Handle `VERSION.SDK_INT < O` by converting epoch millis to `LocalDate` using `Calendar`

No tests were run due to user request.

------
https://chatgpt.com/codex/tasks/task_e_68a646a21a08832cb09399df0687bba3