### PR TITLE
Convert TaskAdapter to view binding

### DIFF
--- a/app/src/main/java/nick/bonson/demotodolist/ui/adapter/TaskAdapter.kt
+++ b/app/src/main/java/nick/bonson/demotodolist/ui/adapter/TaskAdapter.kt
@@ -3,13 +3,10 @@ package nick.bonson.demotodolist.ui.adapter
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.google.android.material.chip.Chip
-import com.google.android.material.checkbox.MaterialCheckBox
-import nick.bonson.demotodolist.R
 import nick.bonson.demotodolist.data.entity.TaskEntity
+import nick.bonson.demotodolist.databinding.ItemTaskBinding
 import nick.bonson.demotodolist.utils.DateFormatter
 import nick.bonson.demotodolist.utils.TaskDiffCallback
 
@@ -17,36 +14,36 @@ class TaskAdapter(private val onItemClick: (TaskEntity) -> Unit) :
     ListAdapter<TaskEntity, TaskAdapter.TaskViewHolder>(TaskDiffCallback) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TaskViewHolder {
-        val view = LayoutInflater.from(parent.context).inflate(R.layout.item_task, parent, false)
-        return TaskViewHolder(view, onItemClick)
+        val binding = ItemTaskBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return TaskViewHolder(binding, onItemClick)
     }
 
     override fun onBindViewHolder(holder: TaskViewHolder, position: Int) {
         holder.bind(getItem(position))
     }
 
-    class TaskViewHolder(itemView: View, private val onItemClick: (TaskEntity) -> Unit) :
-        RecyclerView.ViewHolder(itemView) {
-        private val checkBox: MaterialCheckBox = itemView.findViewById(R.id.task_checkbox)
-        private val title: TextView = itemView.findViewById(R.id.task_title)
-        private val notes: TextView = itemView.findViewById(R.id.task_notes)
-        private val priorityChip: Chip = itemView.findViewById(R.id.chip_priority)
-        private val dueChip: Chip = itemView.findViewById(R.id.chip_due)
+    class TaskViewHolder(
+        private val binding: ItemTaskBinding,
+        private val onItemClick: (TaskEntity) -> Unit
+    ) : RecyclerView.ViewHolder(binding.root) {
+
         private var current: TaskEntity? = null
 
         init {
-            itemView.setOnClickListener { current?.let(onItemClick) }
+            binding.root.setOnClickListener { current?.let(onItemClick) }
         }
 
         fun bind(task: TaskEntity) {
             current = task
-            checkBox.isChecked = task.isDone
-            title.text = task.title
-            notes.text = task.description.orEmpty()
-            notes.visibility = if (task.description.isNullOrBlank()) View.GONE else View.VISIBLE
-            priorityChip.text = task.priority.toString()
-            dueChip.text = task.dueAt?.let(DateFormatter::format) ?: ""
-            dueChip.visibility = if (task.dueAt != null) View.VISIBLE else View.GONE
+            binding.taskCheckbox.isChecked = task.isDone
+            binding.taskTitle.text = task.title
+            binding.taskNotes.text = task.description.orEmpty()
+            binding.taskNotes.visibility =
+                if (task.description.isNullOrBlank()) View.GONE else View.VISIBLE
+            binding.chipPriority.text = task.priority.toString()
+            binding.chipDue.text = task.dueAt?.let(DateFormatter::format) ?: ""
+            binding.chipDue.visibility =
+                if (task.dueAt != null) View.VISIBLE else View.GONE
         }
     }
 }


### PR DESCRIPTION
## Summary
- Refactor TaskAdapter to use ViewBinding (ItemTaskBinding) instead of manual view lookups

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68b412b0af18832cab64bab67cb1997c