### PR TITLE
Persist task checkbox state

### DIFF
--- a/app/src/main/java/nick/bonson/demotodolist/ui/adapter/TaskAdapter.kt
+++ b/app/src/main/java/nick/bonson/demotodolist/ui/adapter/TaskAdapter.kt
@@ -10,12 +10,14 @@ import nick.bonson.demotodolist.databinding.ItemTaskBinding
 import nick.bonson.demotodolist.utils.DateFormatter
 import nick.bonson.demotodolist.utils.TaskDiffCallback
 
-class TaskAdapter(private val onItemClick: (TaskEntity) -> Unit) :
-    ListAdapter<TaskEntity, TaskAdapter.TaskViewHolder>(TaskDiffCallback) {
+class TaskAdapter(
+    private val onItemClick: (TaskEntity) -> Unit,
+    private val onCheckboxClick: (TaskEntity) -> Unit
+) : ListAdapter<TaskEntity, TaskAdapter.TaskViewHolder>(TaskDiffCallback) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TaskViewHolder {
         val binding = ItemTaskBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-        return TaskViewHolder(binding, onItemClick)
+        return TaskViewHolder(binding, onItemClick, onCheckboxClick)
     }
 
     override fun onBindViewHolder(holder: TaskViewHolder, position: Int) {
@@ -24,7 +26,8 @@ class TaskAdapter(private val onItemClick: (TaskEntity) -> Unit) :
 
     class TaskViewHolder(
         private val binding: ItemTaskBinding,
-        private val onItemClick: (TaskEntity) -> Unit
+        private val onItemClick: (TaskEntity) -> Unit,
+        private val onCheckboxClick: (TaskEntity) -> Unit
     ) : RecyclerView.ViewHolder(binding.root) {
 
         private var current: TaskEntity? = null
@@ -35,7 +38,11 @@ class TaskAdapter(private val onItemClick: (TaskEntity) -> Unit) :
 
         fun bind(task: TaskEntity) {
             current = task
+            binding.taskCheckbox.setOnCheckedChangeListener(null)
             binding.taskCheckbox.isChecked = task.isDone
+            binding.taskCheckbox.setOnCheckedChangeListener { _, _ ->
+                onCheckboxClick(task)
+            }
             binding.taskTitle.text = task.title
             binding.taskNotes.text = task.description.orEmpty()
             binding.taskNotes.visibility =

--- a/app/src/main/java/nick/bonson/demotodolist/ui/fragment/TaskListFragment.kt
+++ b/app/src/main/java/nick/bonson/demotodolist/ui/fragment/TaskListFragment.kt
@@ -39,7 +39,10 @@ class TaskListFragment : Fragment() {
         TaskListViewModelFactory(repository, prefs)
     }
 
-    private val adapter = TaskAdapter { task -> showTaskEdit(task) }
+    private val adapter = TaskAdapter(
+        onItemClick = { task -> showTaskEdit(task) },
+        onCheckboxClick = { task -> viewModel.onToggleDone(task) }
+    )
 
     override fun onCreateView(
         inflater: LayoutInflater,


### PR DESCRIPTION
## Summary
- Add checkbox toggle callback in TaskAdapter to persist state
- Wire TaskListFragment to handle checkbox changes via ViewModel

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68b413c3e360832cae9e57dae90cd741