### PR TITLE
Replace numeric priority with icons

### DIFF
--- a/app/src/main/java/nick/bonson/demotodolist/ui/adapter/TaskAdapter.kt
+++ b/app/src/main/java/nick/bonson/demotodolist/ui/adapter/TaskAdapter.kt
@@ -9,6 +9,7 @@ import nick.bonson.demotodolist.data.entity.TaskEntity
 import nick.bonson.demotodolist.databinding.ItemTaskBinding
 import nick.bonson.demotodolist.utils.DateFormatter
 import nick.bonson.demotodolist.utils.TaskDiffCallback
+import nick.bonson.demotodolist.R
 
 class TaskAdapter(
     private val onItemClick: (TaskEntity) -> Unit,
@@ -47,7 +48,15 @@ class TaskAdapter(
             binding.taskNotes.text = task.description.orEmpty()
             binding.taskNotes.visibility =
                 if (task.description.isNullOrBlank()) View.GONE else View.VISIBLE
-            binding.chipPriority.text = task.priority.toString()
+            binding.chipPriority.apply {
+                text = ""
+                when (task.priority) {
+                    0 -> setChipIconResource(R.drawable.stat_1)
+                    1 -> setChipIconResource(R.drawable.stat_2)
+                    2 -> setChipIconResource(R.drawable.stat_3)
+                    else -> chipIcon = null
+                }
+            }
             binding.chipDue.text = task.dueAt?.let(DateFormatter::format) ?: ""
             binding.chipDue.visibility =
                 if (task.dueAt != null) View.VISIBLE else View.GONE


### PR DESCRIPTION
## Summary
- show priority icons instead of numeric values in task list

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68b6e0205a7c832cb0c6c7940c6e9d8b