### PR TITLE
Use ints for searchFlow filtering and sorting

### DIFF
--- a/app/src/main/java/nick/bonson/demotodolist/data/dao/TaskDao.kt
+++ b/app/src/main/java/nick/bonson/demotodolist/data/dao/TaskDao.kt
@@ -3,7 +3,6 @@ package nick.bonson.demotodolist.data.dao
 import androidx.room.*
 import kotlinx.coroutines.flow.Flow
 import nick.bonson.demotodolist.data.entity.TaskEntity
-import nick.bonson.demotodolist.model.Filter
 import nick.bonson.demotodolist.model.TaskSort
 
 @Dao
@@ -48,5 +47,5 @@ interface TaskDao {
             CASE WHEN :sortMode = 1 THEN priority END DESC
         """
     )
-    fun searchFlow(query: String, filter: Filter, sortMode: TaskSort): Flow<List<TaskEntity>>
+    fun searchFlow(query: String, filter: Int, sortMode: Int): Flow<List<TaskEntity>>
 }

--- a/app/src/main/java/nick/bonson/demotodolist/data/repository/TaskRepository.kt
+++ b/app/src/main/java/nick/bonson/demotodolist/data/repository/TaskRepository.kt
@@ -22,7 +22,7 @@ class DefaultTaskRepository(private val dao: TaskDao) : TaskRepository {
         dao.getByStatusFlow(isDone, sortMode)
 
     override fun searchFlow(query: String, filter: Filter, sortMode: TaskSort): Flow<List<TaskEntity>> =
-        dao.searchFlow(query, filter, sortMode)
+        dao.searchFlow(query, filter.ordinal, sortMode.ordinal)
 
     override suspend fun insert(task: TaskEntity) = dao.insert(task)
 


### PR DESCRIPTION
## Summary
- Treat `filter` and `sortMode` as ints in `TaskDao.searchFlow`
- Map `Filter` and `TaskSort` to ordinals before delegating to DAO

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68b6f1683e34832c92ca2b29c60e2825