### PR TITLE
Handle null due dates last in task queries

### DIFF
--- a/app/src/main/java/nick/bonson/demotodolist/data/dao/TaskDao.kt
+++ b/app/src/main/java/nick/bonson/demotodolist/data/dao/TaskDao.kt
@@ -20,6 +20,7 @@ interface TaskDao {
         """
         SELECT * FROM tasks
         ORDER BY
+            CASE WHEN :sortMode = 0 THEN CASE WHEN dueAt IS NULL THEN 1 ELSE 0 END END ASC,
             CASE WHEN :sortMode = 0 THEN dueAt END ASC,
             CASE WHEN :sortMode = 1 THEN priority END DESC
         """
@@ -31,6 +32,7 @@ interface TaskDao {
         SELECT * FROM tasks
         WHERE isDone = :isDone
         ORDER BY
+            CASE WHEN :sortMode = 0 THEN CASE WHEN dueAt IS NULL THEN 1 ELSE 0 END END ASC,
             CASE WHEN :sortMode = 0 THEN dueAt END ASC,
             CASE WHEN :sortMode = 1 THEN priority END DESC
         """
@@ -43,6 +45,7 @@ interface TaskDao {
         WHERE title LIKE '%' || :query || '%'
         AND (:filter = 0 OR (:filter = 1 AND isDone = 0) OR (:filter = 2 AND isDone = 1))
         ORDER BY
+            CASE WHEN :sortMode = 0 THEN CASE WHEN dueAt IS NULL THEN 1 ELSE 0 END END ASC,
             CASE WHEN :sortMode = 0 THEN dueAt END ASC,
             CASE WHEN :sortMode = 1 THEN priority END DESC
         """


### PR DESCRIPTION
## Summary
- ensure tasks without due dates sort after those with due dates
- apply null-aware ordering to all task queries

## Testing
- ⚠️ no tests run

------
https://chatgpt.com/codex/tasks/task_e_68b6f7f650b4832c8fb5039b218e86c5