### PR TITLE
Use TaskSort consistently with TypeConverter

### DIFF
--- a/app/src/main/java/nick/bonson/demotodolist/data/dao/TaskDao.kt
+++ b/app/src/main/java/nick/bonson/demotodolist/data/dao/TaskDao.kt
@@ -1,11 +1,13 @@
 package nick.bonson.demotodolist.data.dao
 
 import androidx.room.*
+import nick.bonson.demotodolist.data.db.TaskSortConverters
 import kotlinx.coroutines.flow.Flow
 import nick.bonson.demotodolist.data.entity.TaskEntity
 import nick.bonson.demotodolist.model.TaskSort
 
 @Dao
+@TypeConverters(TaskSortConverters::class)
 interface TaskDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(task: TaskEntity)
@@ -47,5 +49,5 @@ interface TaskDao {
             CASE WHEN :sortMode = 1 THEN priority END DESC
         """
     )
-    fun searchFlow(query: String, filter: Int, sortMode: Int): Flow<List<TaskEntity>>
+    fun searchFlow(query: String, filter: Int, sortMode: TaskSort): Flow<List<TaskEntity>>
 }

--- a/app/src/main/java/nick/bonson/demotodolist/data/db/TaskSortConverters.kt
+++ b/app/src/main/java/nick/bonson/demotodolist/data/db/TaskSortConverters.kt
@@ -1,0 +1,13 @@
+package nick.bonson.demotodolist.data.db
+
+import androidx.room.TypeConverter
+import nick.bonson.demotodolist.model.TaskSort
+
+class TaskSortConverters {
+    @TypeConverter
+    fun fromTaskSort(sort: TaskSort): Int = sort.ordinal
+
+    @TypeConverter
+    fun toTaskSort(value: Int): TaskSort = TaskSort.values()[value]
+}
+

--- a/app/src/main/java/nick/bonson/demotodolist/data/repository/TaskRepository.kt
+++ b/app/src/main/java/nick/bonson/demotodolist/data/repository/TaskRepository.kt
@@ -22,7 +22,7 @@ class DefaultTaskRepository(private val dao: TaskDao) : TaskRepository {
         dao.getByStatusFlow(isDone, sortMode)
 
     override fun searchFlow(query: String, filter: Filter, sortMode: TaskSort): Flow<List<TaskEntity>> =
-        dao.searchFlow(query, filter.ordinal, sortMode.ordinal)
+        dao.searchFlow(query, filter.ordinal, sortMode)
 
     override suspend fun insert(task: TaskEntity) = dao.insert(task)
 


### PR DESCRIPTION
## Summary
- add Room type converters for TaskSort enum
- use TaskSort for sortMode across DAO and repository

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68b6f7fe3f7c832c90fc046e6514ab45