### PR TITLE
Fix sort menu check toggle

### DIFF
--- a/app/src/main/java/nick/bonson/demotodolist/ui/fragment/TaskListFragment.kt
+++ b/app/src/main/java/nick/bonson/demotodolist/ui/fragment/TaskListFragment.kt
@@ -75,10 +75,14 @@ class TaskListFragment : Fragment() {
         toolbar.setOnMenuItemClickListener { item ->
             when (item.itemId) {
                 R.id.action_sort_due -> {
+                    item.isChecked = true
+                    toolbar.menu.findItem(R.id.action_sort_priority).isChecked = false
                     viewModel.onSortChanged(TaskSort.BY_DUE_AT)
                     true
                 }
                 R.id.action_sort_priority -> {
+                    item.isChecked = true
+                    toolbar.menu.findItem(R.id.action_sort_due).isChecked = false
                     viewModel.onSortChanged(TaskSort.BY_PRIORITY)
                     true
                 }


### PR DESCRIPTION
## Summary
- ensure only one sort option is checked at a time in task list menu

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68b6ff1f88ac832cb68c2e652462d8a9